### PR TITLE
Chore(devcontainer): Update configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,18 +4,16 @@
     "../.docker/docker-compose.dev.yml",
     "docker-compose.yml"
   ],
-  "service": "jupyter",
+  "service": "conda-math-repo-template",
   "workspaceFolder": "/utkusarioglu-com/templates/conda-math-repo-template",
   "settings": {
     "workbench.colorCustomizations": {
-      "activityBar.background": "#002244"
+      "activityBar.background": "#FF0000",
+      "activityBar.foreground": "#000000"
     }
   },
   "extensions": [
     "ms-python.python",
     "ms-toolsai.jupyter"
-  ],
-  "features": {
-    "github-cli": "latest"
-  }
+  ]
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,12 +1,19 @@
 version: "3.9"
 services:
-  jupyter:
+  conda-math-repo-template:
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
     volumes:
-      - vscode-extensions:/root/.vscode-server/extensions
-      - vscode-extensions-insiders:/root/.vscode-server-insiders/extensions
-      - ~/.config/gh:/home/econ/.config/gh:ro
+      - type: volume
+        source: vscode-server-extensions
+        target: /home/math/.vscode-server/extensions
+      - type: volume
+        source: vscode-server-insiders-extensions
+        target: /home/math/.vscode-server-insiders/extensions
     command: /bin/sh -c "while sleep 1000; do :; done"
 
 volumes:
-  vscode-extensions:
-  vscode-extensions-insiders:
+  vscode-server-extensions:
+    name: conta-math-repo-template-vscode-server-extensions
+  vscode-server-insiders-extensions:
+    name: conta-math-repo-template-vscode-server-insiders-extensions

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -1,7 +1,9 @@
 version: "3.9"
 
 services:
-  jupyter:
-    image: utkusarioglu/conda-math-devcontainer:1.0.3
+  conda-math-repo-template:
+    image: utkusarioglu/conda-math-devcontainer:1.0.8
     volumes:
-      - ..:/utkusarioglu-com/templates/conda-math-repo-template
+      - type: bind
+        source: ..
+        target: /utkusarioglu-com/templates/conda-math-repo-template


### PR DESCRIPTION
- Refactor volumes to use long syntax.
- Upgrade devcontainer image to 1.0.8.
- Rename volumes to be unique.
- Define environment variable `GH_TOKEN` for allowing github to assume
  host config.
- Remove github-cli from devcontainer features. This is because now the
  cli tool consumed through devcontainer image.
