### PR TITLE
Chore: Add test monitor

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,7 +2,9 @@ version: "3.9"
 
 services:
   conda-math-repo-template:
-    image: utkusarioglu/conda-math-devcontainer:1.0.8
+    image: utkusarioglu/conda-math-devcontainer:1.0.10
+    environment:
+      PYTHONPATH: /utkusarioglu-com/templates/conda-math-repo-template
     volumes:
       - type: bind
         source: ..

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 __pycache__
 .ipynb_checkpoints
+.pytest_cache

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Test Monitor",
+      "detail": "Run tests",
+      "type": "shell",
+      "command": "scripts/test-monitor.sh",
+      "icon": {
+        "color": "terminal.ansiYellow",
+        "id": "beaker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      }
+    }
+  ]
+}

--- a/scripts/test-monitor.sh
+++ b/scripts/test-monitor.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Starting watchmedo for pytest…"
+watchmedo shell-command \
+  --patterns "*.py" \
+  --recursive \
+  --command "\
+      pytest src \
+    " \
+  .

--- a/src/greeting/greeting_utils.py
+++ b/src/greeting/greeting_utils.py
@@ -1,0 +1,2 @@
+def returns_greeting():
+  return "Hello there"

--- a/src/greeting/greeting_utils_unit_test.py
+++ b/src/greeting/greeting_utils_unit_test.py
@@ -1,0 +1,6 @@
+from greeting_utils import returns_greeting
+
+def test_returns_greeting():
+  response = returns_greeting()
+  expected = "Hello there"
+  assert(expected == response)

--- a/src/main.ipynb
+++ b/src/main.ipynb
@@ -1,18 +1,38 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 1,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Hello\n",
-    "\n",
-    "Just start doing your thing"
+    "from greeting.greeting_utils import returns_greeting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello there'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "returns_greeting()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('econ')",
+   "display_name": "Python 3.10.6 ('econ')",
    "language": "python",
    "name": "python3"
   },
@@ -26,12 +46,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.6"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "26344e8bbd46e7a04ef130f02631069aca47e31275ff414818183f6d42ed8ef5"
+    "hash": "7c2280d020ed2aed7cdac8de3c4dba8c6872048e6115fb0655eb08d156aeaec0"
    }
   }
  },


### PR DESCRIPTION
- Add test monitor for automatically running tests when something changes.
- Include `pytest_cache` in `.gitignore`
- Update `main.ipynb` to import a module, which can be symbolically
  tested by the test tool. This is meant as a guide to the devs who
  consume this template.
- Add `test-monitor.sh` script as a facade to the watchmedo command that
  needs to be run to monitor pytest.
- Add `tasks.json` to conveniently call the `test-monitor.sh` script.
