### PR TITLE
Fix: Typo in volume names

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,6 +14,6 @@ services:
 
 volumes:
   vscode-server-extensions:
-    name: conta-math-repo-template-vscode-server-extensions
+    name: conda-math-repo-template-vscode-server-extensions
   vscode-server-insiders-extensions:
-    name: conta-math-repo-template-vscode-server-insiders-extensions
+    name: conda-math-repo-template-vscode-server-insiders-extensions


### PR DESCRIPTION
- Closes #5 by fixing the volume names in `docker-compose.yml`.
